### PR TITLE
Estalillaj/policy from reports

### DIFF
--- a/csp-auditor-core/src/main/java/ca/gosecure/cspauditor/gui/generator/CspGeneratorPanel.form
+++ b/csp-auditor-core/src/main/java/ca/gosecure/cspauditor/gui/generator/CspGeneratorPanel.form
@@ -79,7 +79,7 @@
                             <constraints border-constraint="Center"/>
                             <properties>
                               <editable value="false"/>
-                              <text value="Warning: The following configuration might not be complete. Refer to &quot;Inline Scripts&quot; to see scripts that are not compatible with CSP strict mode (No use of &quot;script-src 'unsafe-inline'&quot;)."/>
+                              <text value="Warning: The following configuration might not be complete. 1) Frame-Ancestors cannot currently be detected for different domains 2) Refer to &quot;Inline Scripts&quot; to see scripts that are not compatible with CSP strict mode (No use of &quot;script-src 'unsafe-inline'&quot;)."/>
                             </properties>
                           </component>
                         </children>


### PR DESCRIPTION
@h3xstream 
Addresses #2 .

Builds the policy from the reports.
Fixes a quoting issue with "self".
Doesn't add frame-ancestors unless the report has a referrer.

Didn't implement export report functionality since that can be done by burp natively.
